### PR TITLE
[iOS] view binding, 숫자 콤마 추가 및 소수점 2자리 변환, 키보드 툴바 추가

### DIFF
--- a/WirebarleyTest/WirebarleyTest.xcodeproj/project.pbxproj
+++ b/WirebarleyTest/WirebarleyTest.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		C116519925ADB46E00B4B59B /* Quote.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116519825ADB46E00B4B59B /* Quote.swift */; };
 		C11651A125ADC67200B4B59B /* ExchangeRateData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11651A025ADC67200B4B59B /* ExchangeRateData.swift */; };
 		C1613F9225B0762700F4B2D1 /* extension+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1613F9125B0762700F4B2D1 /* extension+Date.swift */; };
+		C185EFB825B0900100E144F5 /* extension+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = C185EFB725B0900100E144F5 /* extension+String.swift */; };
 		C18AAE2225AD61FA00730F30 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18AAE2125AD61FA00730F30 /* AppDelegate.swift */; };
 		C18AAE2425AD61FA00730F30 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18AAE2325AD61FA00730F30 /* SceneDelegate.swift */; };
 		C18AAE2625AD61FA00730F30 /* CalculationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18AAE2525AD61FA00730F30 /* CalculationController.swift */; };
@@ -59,6 +60,7 @@
 		C116519825ADB46E00B4B59B /* Quote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quote.swift; sourceTree = "<group>"; };
 		C11651A025ADC67200B4B59B /* ExchangeRateData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateData.swift; sourceTree = "<group>"; };
 		C1613F9125B0762700F4B2D1 /* extension+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "extension+Date.swift"; sourceTree = "<group>"; };
+		C185EFB725B0900100E144F5 /* extension+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "extension+String.swift"; sourceTree = "<group>"; };
 		C18AAE1E25AD61FA00730F30 /* WirebarleyTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WirebarleyTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C18AAE2125AD61FA00730F30 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C18AAE2325AD61FA00730F30 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 			children = (
 				C116518625ADAFE900B4B59B /* APIService.swift */,
 				C1613F9125B0762700F4B2D1 /* extension+Date.swift */,
+				C185EFB725B0900100E144F5 /* extension+String.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -496,6 +499,7 @@
 				C116519925ADB46E00B4B59B /* Quote.swift in Sources */,
 				C116518025AD9F1500B4B59B /* CalculationViewModel.swift in Sources */,
 				C116518F25ADB32300B4B59B /* CalculationRepository.swift in Sources */,
+				C185EFB825B0900100E144F5 /* extension+String.swift in Sources */,
 				C1613F9225B0762700F4B2D1 /* extension+Date.swift in Sources */,
 				C116518725ADAFE900B4B59B /* APIService.swift in Sources */,
 				C18AAE2625AD61FA00730F30 /* CalculationController.swift in Sources */,

--- a/WirebarleyTest/WirebarleyTest.xcodeproj/project.pbxproj
+++ b/WirebarleyTest/WirebarleyTest.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		C116519425ADB3DC00B4B59B /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116519325ADB3DC00B4B59B /* Response.swift */; };
 		C116519925ADB46E00B4B59B /* Quote.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116519825ADB46E00B4B59B /* Quote.swift */; };
 		C11651A125ADC67200B4B59B /* ExchangeRateData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11651A025ADC67200B4B59B /* ExchangeRateData.swift */; };
+		C1613F9225B0762700F4B2D1 /* extension+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1613F9125B0762700F4B2D1 /* extension+Date.swift */; };
 		C18AAE2225AD61FA00730F30 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18AAE2125AD61FA00730F30 /* AppDelegate.swift */; };
 		C18AAE2425AD61FA00730F30 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18AAE2325AD61FA00730F30 /* SceneDelegate.swift */; };
 		C18AAE2625AD61FA00730F30 /* CalculationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18AAE2525AD61FA00730F30 /* CalculationController.swift */; };
@@ -57,6 +58,7 @@
 		C116519325ADB3DC00B4B59B /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		C116519825ADB46E00B4B59B /* Quote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quote.swift; sourceTree = "<group>"; };
 		C11651A025ADC67200B4B59B /* ExchangeRateData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRateData.swift; sourceTree = "<group>"; };
+		C1613F9125B0762700F4B2D1 /* extension+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "extension+Date.swift"; sourceTree = "<group>"; };
 		C18AAE1E25AD61FA00730F30 /* WirebarleyTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WirebarleyTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C18AAE2125AD61FA00730F30 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C18AAE2325AD61FA00730F30 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 			isa = PBXGroup;
 			children = (
 				C116518625ADAFE900B4B59B /* APIService.swift */,
+				C1613F9125B0762700F4B2D1 /* extension+Date.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -493,6 +496,7 @@
 				C116519925ADB46E00B4B59B /* Quote.swift in Sources */,
 				C116518025AD9F1500B4B59B /* CalculationViewModel.swift in Sources */,
 				C116518F25ADB32300B4B59B /* CalculationRepository.swift in Sources */,
+				C1613F9225B0762700F4B2D1 /* extension+Date.swift in Sources */,
 				C116518725ADAFE900B4B59B /* APIService.swift in Sources */,
 				C18AAE2625AD61FA00730F30 /* CalculationController.swift in Sources */,
 				C18AAE2225AD61FA00730F30 /* AppDelegate.swift in Sources */,

--- a/WirebarleyTest/WirebarleyTest/Base.lproj/Main.storyboard
+++ b/WirebarleyTest/WirebarleyTest/Base.lproj/Main.storyboard
@@ -22,23 +22,23 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="VNB-S4-8gH">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="VNB-S4-8gH">
                                 <rect key="frame" x="151" y="198" width="138.5" height="148.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미국 (USD)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p05-Xe-ozw">
-                                        <rect key="frame" x="0.0" y="0.0" width="138.5" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="80.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="한국 (KRW)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jld-kP-giE">
-                                        <rect key="frame" x="0.0" y="30.5" width="138.5" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="30.5" width="83.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KRW / USD" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="26r-g6-IdX">
-                                        <rect key="frame" x="0.0" y="61" width="138.5" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="61" width="85.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -49,16 +49,20 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2wa-8j-2Ad">
-                                        <rect key="frame" x="0.0" y="122" width="138.5" height="26.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2wa-8j-2Ad">
+                                        <rect key="frame" x="0.0" y="122" width="128" height="26.5"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bla-Go-8Cj">
-                                                <rect key="frame" x="0.0" y="0.0" width="96" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="60" height="26.5"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="60" id="FzI-uu-wvV"/>
+                                                    <constraint firstAttribute="height" constant="26.5" id="p4y-mY-kEt"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
+                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="USD" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mmX-gr-SdA">
-                                                <rect key="frame" x="104" y="0.0" width="34.5" height="26.5"/>
+                                                <rect key="frame" x="68" y="0.0" width="60" height="26.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -102,8 +106,8 @@
                                     </label>
                                 </subviews>
                             </stackView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="수취금액은 113,004.98 KRW 입니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uBg-CW-86N">
-                                <rect key="frame" x="57.5" y="420" width="299.5" height="24"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="송금액을 입력해주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uBg-CW-86N">
+                                <rect key="frame" x="115.5" y="420" width="183" height="24"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/WirebarleyTest/WirebarleyTest/Base.lproj/Main.storyboard
+++ b/WirebarleyTest/WirebarleyTest/Base.lproj/Main.storyboard
@@ -23,42 +23,42 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="VNB-S4-8gH">
-                                <rect key="frame" x="151" y="198" width="160" height="148.5"/>
+                                <rect key="frame" x="151" y="198" width="138.5" height="148.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미국 (USD)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p05-Xe-ozw">
-                                        <rect key="frame" x="0.0" y="0.0" width="160" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="138.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="한국 (KRW)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jld-kP-giE">
-                                        <rect key="frame" x="0.0" y="30.5" width="160" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="30.5" width="138.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1,1130.05 KRW / USD" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="26r-g6-IdX">
-                                        <rect key="frame" x="0.0" y="61" width="160" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KRW / USD" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="26r-g6-IdX">
+                                        <rect key="frame" x="0.0" y="61" width="138.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2019-03-20 16:13" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a6b-3R-G9X">
-                                        <rect key="frame" x="0.0" y="91.5" width="160" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="91.5" width="138.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2wa-8j-2Ad">
-                                        <rect key="frame" x="0.0" y="122" width="160" height="26.5"/>
+                                        <rect key="frame" x="0.0" y="122" width="138.5" height="26.5"/>
                                         <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bla-Go-8Cj">
-                                                <rect key="frame" x="0.0" y="0.0" width="117.5" height="26.5"/>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bla-Go-8Cj">
+                                                <rect key="frame" x="0.0" y="0.0" width="96" height="26.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="USD" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mmX-gr-SdA">
-                                                <rect key="frame" x="125.5" y="0.0" width="34.5" height="26.5"/>
+                                                <rect key="frame" x="104" y="0.0" width="34.5" height="26.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>

--- a/WirebarleyTest/WirebarleyTest/Repository/CalculationRepository.swift
+++ b/WirebarleyTest/WirebarleyTest/Repository/CalculationRepository.swift
@@ -23,6 +23,7 @@ class CalculationRepository: RatesFetchable {
                         return
                     }
                     emitter.onNext(response.quotes)
+                    emitter.onCompleted()
                 case .failure(let error):
                     emitter.onError(error)
                 }

--- a/WirebarleyTest/WirebarleyTest/Util/extension+Date.swift
+++ b/WirebarleyTest/WirebarleyTest/Util/extension+Date.swift
@@ -1,0 +1,17 @@
+//
+//  extension+Date.swift
+//  WirebarleyTest
+//
+//  Created by 남기범 on 2021/01/14.
+//
+
+import Foundation
+
+extension Date {
+    func toString() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+        
+        return dateFormatter.string(from: self)
+    }
+}

--- a/WirebarleyTest/WirebarleyTest/Util/extension+String.swift
+++ b/WirebarleyTest/WirebarleyTest/Util/extension+String.swift
@@ -1,0 +1,36 @@
+//
+//  extension+String.swift
+//  WirebarleyTest
+//
+//  Created by 남기범 on 2021/01/14.
+//
+
+import Foundation
+
+extension String{
+    func getArrayAfterRegex(regex: String) -> [String] {
+        do {
+            let regex = try NSRegularExpression(pattern: regex)
+            let results = regex.matches(in: self,
+                                        range: NSRange(self.startIndex..., in: self))
+            return results.map {
+                String(self[Range($0.range, in: self)!])
+            }
+        } catch let error {
+            print("invalid regex: \(error.localizedDescription)")
+            return []
+        }
+    }
+    
+    func toDecimal() -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumFractionDigits = 2
+        numberFormatter.minimumFractionDigits = 2
+        guard let result = numberFormatter.string(from: NSNumber(value: Double(self) ?? 0)) else {
+            fatalError("Double value doesn't convert String")
+        }
+        
+        return result
+    }
+}

--- a/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
+++ b/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
@@ -21,6 +21,7 @@ class CalculationController: UIViewController {
     
     private let viewModel = CalculationViewModel()
     private let disposeBag = DisposeBag()
+    private let countrys = ["한국(KRW)", "일본(JPY)", "필리핀(PHP)"]
     private var currentRate: Double = 0
     
     override func viewDidLoad() {
@@ -49,12 +50,6 @@ private extension CalculationController {
             }
             .bind(to: exchangeRateLabel.rx.text)
             .disposed(by: disposeBag)
-        
-        if !viewModel.countrysData.isEmpty {
-            viewModel.quotes.onNext(viewModel.countrysData[0])
-        } else {
-            viewModel.quotes.onNext(ExchangeRateData(송금국가: "미국(USD)", 수취국가: "한국(KSW)", 환율: "재조회 필요"))
-        }
     }
     
     func valueConverting(value: String) -> String {
@@ -100,11 +95,11 @@ extension CalculationController: UIPickerViewDelegate, UIPickerViewDataSource {
     }
     
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return viewModel.countrysData.count
+        return countrys.count
     }
     
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return viewModel.countrysData[row].수취국가
+        return countrys[row]
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {

--- a/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
+++ b/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
@@ -19,12 +19,31 @@ class CalculationController: UIViewController {
     @IBOutlet weak var resultLabel: UILabel!
     @IBOutlet weak var countryPicker: UIPickerView!
     
-    private let countrys = ["한국(KRW)", "일본(JPY)", "필리핀(PHP)"]
+    private let viewModel = CalculationViewModel()
+    private let disposeBag = DisposeBag()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        viewBinding()
+        viewModel.quotes.onNext(viewModel.countrysData[0])
         countryPicker.delegate = self
+    }
+}
+
+private extension CalculationController {
+    func viewBinding() {
+        viewModel.remittanceCountry
+            .bind(to: remittanceCountryLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        viewModel.recipientCountry
+            .bind(to: recipientCountryLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        viewModel.exchangeRate
+            .bind(to: exchangeRateLabel.rx.text)
+            .disposed(by: disposeBag)
     }
 }
 
@@ -34,14 +53,14 @@ extension CalculationController: UIPickerViewDelegate, UIPickerViewDataSource {
     }
     
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return countrys.count
+        return viewModel.countrysData.count
     }
     
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return countrys[row]
+        return viewModel.countrysData[row].수취국가
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        print(row)
+        viewModel.quotes.onNext(viewModel.countrysData[row])
     }
 }

--- a/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
+++ b/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
@@ -26,6 +26,7 @@ class CalculationController: UIViewController {
         super.viewDidLoad()
         
         viewBinding()
+        timeLabel.text = Date().toString()
         viewModel.quotes.onNext(viewModel.countrysData[0])
         countryPicker.delegate = self
     }

--- a/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
+++ b/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
@@ -50,6 +50,10 @@ private extension CalculationController {
             }
             .bind(to: exchangeRateLabel.rx.text)
             .disposed(by: disposeBag)
+        
+        if !viewModel.countrysData.isEmpty {
+            viewModel.quotes.onNext(viewModel.countrysData[0])
+        }
     }
     
     func valueConverting(value: String) -> String {

--- a/WirebarleyTest/WirebarleyTest/ViewModel/CalculationViewModel.swift
+++ b/WirebarleyTest/WirebarleyTest/ViewModel/CalculationViewModel.swift
@@ -14,6 +14,7 @@ protocol CalculationViewModelType {
     var remittanceCountry: Observable<String> { get }
     var recipientCountry: Observable<String> { get }
     var exchangeRate: Observable<String> { get }
+    var countrysData: [ExchangeRateData] { get }
 }
 
 class CalculationViewModel: CalculationViewModelType {
@@ -34,9 +35,9 @@ class CalculationViewModel: CalculationViewModelType {
             .subscribeOn(MainScheduler.instance)
             .subscribe(onNext: { element in
                 self.countrysData = [
-                    ExchangeRateData(송금국가: "미국(USD)", 수취국가: "한국(KRW)", 환율: "\(element.USDKRW)"),
-                    ExchangeRateData(송금국가: "미국(USD)", 수취국가: "일본(JPY)", 환율: "\(element.USDJPY)"),
-                    ExchangeRateData(송금국가: "미국(USD)", 수취국가: "필리핀(PHP)", 환율: "\(element.USDPHP)")
+                    ExchangeRateData(송금국가: "미국(USD)", 수취국가: "한국(KRW)", 환율: "\(element.USDKRW) KRW / USD"),
+                    ExchangeRateData(송금국가: "미국(USD)", 수취국가: "일본(JPY)", 환율: "\(element.USDJPY) JPY / USD"),
+                    ExchangeRateData(송금국가: "미국(USD)", 수취국가: "필리핀(PHP)", 환율: "\(element.USDPHP) PHP / USD")
                 ]
             }, onCompleted: {
                 print("data setting is successful.")

--- a/WirebarleyTest/WirebarleyTest/ViewModel/CalculationViewModel.swift
+++ b/WirebarleyTest/WirebarleyTest/ViewModel/CalculationViewModel.swift
@@ -31,6 +31,7 @@ class CalculationViewModel: CalculationViewModelType {
         exchangeRate = quotes.map { $0.환율 }
         
         repository.fetchRates()
+            .subscribeOn(MainScheduler.instance)
             .subscribe(onNext: { element in
                 self.countrysData = [
                     ExchangeRateData(송금국가: "미국(USD)", 수취국가: "한국(KRW)", 환율: "\(element.USDKRW)"),

--- a/WirebarleyTest/WirebarleyTest/ViewModel/CalculationViewModel.swift
+++ b/WirebarleyTest/WirebarleyTest/ViewModel/CalculationViewModel.swift
@@ -33,14 +33,16 @@ class CalculationViewModel: CalculationViewModelType {
         
         repository.fetchRates()
             .subscribeOn(MainScheduler.instance)
-            .subscribe(onNext: { element in
-                self.countrysData = [
+            .subscribe(onNext: { [weak self] element in
+                self?.countrysData = [
                     ExchangeRateData(송금국가: "미국(USD)", 수취국가: "한국(KRW)", 환율: "\(element.USDKRW) KRW / USD"),
                     ExchangeRateData(송금국가: "미국(USD)", 수취국가: "일본(JPY)", 환율: "\(element.USDJPY) JPY / USD"),
                     ExchangeRateData(송금국가: "미국(USD)", 수취국가: "필리핀(PHP)", 환율: "\(element.USDPHP) PHP / USD")
                 ]
-            }, onCompleted: {
-                print("data setting is successful.")
+            }, onCompleted: { [weak self] in
+                self?.quotes.onNext(self?.countrysData[0] ?? ExchangeRateData(송금국가: "미국(USD)",
+                                                                              수취국가: "한국(KRW)",
+                                                                              환율: "0.0 KRW / USD"))
             }).disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## 구현 항목
- ViewModel을 연동해서 view에 데이터를 바인딩해줬습니다.
- 숫자에 콤마를 추가하고 소수점 2자리까지 제한을 뒀습니다.
- 키보드에 툴바를 추가하고 Done 버튼을 누르면 계산이 완료되게 했습니다.
- 데이터를 받아오는 시점이 뷰에 바인딩하는 시점보다 빠른 경우도 있고, 느린 경우도 있어서 뷰가 갱신되지 않는 현상이 있었습니다. 그래서 바인딩 되기 이전에 이벤트가 일어나서 갱신이 안됐을 경우, 이벤트를 한 번 더 보내서 갱신되도록 처리했습니다.

## 해야 할 것
- [x] unit test를 구현체가 아닌 protocol로 하기
- [x] readme 작성
- [x] `수취금액이 0보다 작은 금액이거나 10,000 USD 보다 큰 금액, 혹은 바른 숫자가 아니라면 “송금액이 바르지 않습니다"라는 에러 메시지를 보여줍니다. 메시지는 팝업, 혹은 하단에 빨간 글씨로 나타나면 됩니다.` 요구사항 에러처리