### PR TITLE
[iOS] 의존성 주입 및 테스트, 송금액 에러 처리

### DIFF
--- a/WirebarleyTest/WirebarleyTest/Repository/CalculationRepository.swift
+++ b/WirebarleyTest/WirebarleyTest/Repository/CalculationRepository.swift
@@ -9,13 +9,15 @@ import Foundation
 import RxSwift
 
 protocol RatesFetchable {
-    func fetchRates() -> Observable<Quote>
+    func fetchRates(apiService: FetchAPIData) -> Observable<Quote>
 }
 
 class CalculationRepository: RatesFetchable {
-    func fetchRates() -> Observable<Quote> {
-        return Observable.create({ emitter in
-            APIService.shared.request(urlString: url, completion: { result in
+    private let url = "http://api.currencylayer.com/live?access_key=7063bbdf25d9f939368df1c8087adde1"
+    
+    func fetchRates(apiService: FetchAPIData) -> Observable<Quote> {
+        return Observable.create({ [weak self] emitter in
+            apiService.request(urlString: self?.url ?? "", completion: { result in
                 switch result {
                 case .success(let data):
                     guard let response = try? JSONDecoder().decode(Response<Quote>.self, from: data) else {

--- a/WirebarleyTest/WirebarleyTest/Util/APIService.swift
+++ b/WirebarleyTest/WirebarleyTest/Util/APIService.swift
@@ -12,12 +12,12 @@ enum NetworkError: Error {
     case noData
 }
 
-let url = "http://api.currencylayer.com/live?access_key=7063bbdf25d9f939368df1c8087adde1"
+protocol FetchAPIData {
+    func request(urlString: String, completion: @escaping (Result<Data, NetworkError>) -> Void)
+}
 
-class APIService {
-    static let shared = APIService()
-    
-    func request(urlString: String, body: Data? = nil, completion: @escaping (Result<Data, NetworkError>)-> Void) {
+class APIService: FetchAPIData {
+    func request(urlString: String, completion: @escaping (Result<Data, NetworkError>)-> Void) {
         guard let url = URL(string: urlString) else {
             return
         }

--- a/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
+++ b/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
@@ -89,11 +89,16 @@ private extension CalculationController {
     
     @objc func doneAction() {
         guard let moneyUnit = (recipientCountryLabel.text ?? "").getArrayAfterRegex(regex: "[A-Z]+").first,
-              let value = Double(moneyTextField.text ?? "") else {
+              let value = Double(moneyTextField.text ?? ""),
+              (value > 0.0 && value <= 10000.0) else {
+            resultLabel.textColor = .red
+            resultLabel.text = "송금액이 올바르지 않습니다."
+            view.endEditing(true)
             return
         }
         
         let result = "\(currentRate * value)".toDecimal()
+        resultLabel.textColor = .black
         resultLabel.text = "수취금액은 " + "\(result)" + " \(moneyUnit)" + " 입니다."
         
         view.endEditing(true)
@@ -116,6 +121,7 @@ extension CalculationController: UIPickerViewDelegate, UIPickerViewDataSource {
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         viewModel.quotes.onNext(viewModel.countrysData[row])
         moneyTextField.text = ""
+        resultLabel.textColor = .black
         resultLabel.text = "송금액을 입력해주세요."
     }
 }

--- a/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
+++ b/WirebarleyTest/WirebarleyTest/View/CalculationController.swift
@@ -19,10 +19,17 @@ class CalculationController: UIViewController {
     @IBOutlet weak var resultLabel: UILabel!
     @IBOutlet weak var countryPicker: UIPickerView!
     
-    private let viewModel = CalculationViewModel()
+    private var viewModel: CalculationViewModelType
     private let disposeBag = DisposeBag()
     private let countrys = ["한국(KRW)", "일본(JPY)", "필리핀(PHP)"]
     private var currentRate: Double = 0
+    
+    required init?(coder: NSCoder) {
+        let apiService = APIService()
+        let repository = CalculationRepository()
+        viewModel = CalculationViewModel(repository: repository, apiService: apiService)
+        super.init(coder: coder)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/WirebarleyTest/WirebarleyTest/ViewModel/CalculationViewModel.swift
+++ b/WirebarleyTest/WirebarleyTest/ViewModel/CalculationViewModel.swift
@@ -25,13 +25,13 @@ class CalculationViewModel: CalculationViewModelType {
     var disposeBag: DisposeBag = DisposeBag()
     var countrysData: [ExchangeRateData] = []
     
-    init(repository: RatesFetchable = CalculationRepository()) {
+    init(repository: RatesFetchable, apiService: FetchAPIData) {
         quotes = PublishSubject<ExchangeRateData>()
         remittanceCountry = quotes.map { $0.송금국가 }
         recipientCountry = quotes.map { $0.수취국가 }
         exchangeRate = quotes.map { $0.환율 }
         
-        repository.fetchRates()
+        repository.fetchRates(apiService: apiService)
             .subscribeOn(MainScheduler.instance)
             .subscribe(onNext: { [weak self] element in
                 self?.countrysData = [
@@ -39,6 +39,8 @@ class CalculationViewModel: CalculationViewModelType {
                     ExchangeRateData(송금국가: "미국(USD)", 수취국가: "일본(JPY)", 환율: "\(element.USDJPY) JPY / USD"),
                     ExchangeRateData(송금국가: "미국(USD)", 수취국가: "필리핀(PHP)", 환율: "\(element.USDPHP) PHP / USD")
                 ]
+            }, onError: { [weak self] error in
+                self?.quotes.onError(error)
             }, onCompleted: { [weak self] in
                 self?.quotes.onNext(self?.countrysData[0] ?? ExchangeRateData(송금국가: "미국(USD)",
                                                                               수취국가: "한국(KRW)",


### PR DESCRIPTION
## 구현 항목
- 의존성 주입을 위해 코드를 수정했습니다. 또한 클래스들을 protocol로 추상화하여 unit test에서 프로토콜을 상속받은 목업 class를 재정의한 뒤 테스트를 진행했습니다. 의존성 주입을 고려한 이유는 pure하지 않은 클래스들이 많이 존재했고, pure하지 않으면 테스트 코드를 작성할 때 외부 코드에 의존적이기 때문입니다. [- 참고 링크](https://medium.com/@m25lazi/unit-testing-swift-code-with-protocols-7aa0b8d7816d)
- 요구사항에 있던 송금액 크기에 따른 에러처리를 해줬습니다.